### PR TITLE
feat: Enable preserving in-app config changes on startup

### DIFF
--- a/foundryvtt/README.md
+++ b/foundryvtt/README.md
@@ -17,6 +17,7 @@ A Helm chart for Foundry VTT
 | config.downloadRetries | int | `3` | Number of times the container will try to download the foundry binary |
 | config.enableTelemetry | bool | `false` | Defines if telemetry data are allowed to be tracked |
 | config.minifyStaticFiles | bool | `true` | Defines if static files should be minified |
+| config.preserveConfig | bool | `false` | Defines if in-app configuration changes should be preserved across container restarts |
 | existingSecret | object | `{"containsAwsConfig":false,"containsLicenseKey":false,"name":null}` | Config for the existing secret that will be referenced by the container. By default the name of the secret that is looked for is the name of the release. The secret is required to have a key foundry-username and foundry-password with the user credentials to download the foundry version. Also a "admin-key" must be provided in the secret. |
 | existingSecret.containsAwsConfig | bool | `false` | Set tot true if the secret contains an awsConfig.json key |
 | existingSecret.containsLicenseKey | bool | `false` | Set to true if the secret contains a license key to use. The key that is uses is foundry-license-key |
@@ -58,4 +59,3 @@ A Helm chart for Foundry VTT
 | storage.className | string | `nil` | The storage class name to use |
 | storage.size | string | `"10Gi"` | The size the pv should have |
 | tolerations | list | `[]` |  |
-

--- a/foundryvtt/templates/statefulset.yaml
+++ b/foundryvtt/templates/statefulset.yaml
@@ -38,6 +38,8 @@ spec:
           env:
             - name: CONTAINER_URL_FETCH_RETRY
               value: {{ .Values.config.downloadRetries | quote }}
+            - name: CONTAINER_PRESERVE_CONFIG
+              value: {{ .Values.config.preserveConfig | quote }}
             - name: FOUNDRY_MINIFY_STATIC_FILES
               value: {{ .Values.config.minifyStaticFiles | quote }}
             - name: FOUNDRY_TELEMETRY

--- a/foundryvtt/values.yaml
+++ b/foundryvtt/values.yaml
@@ -5,6 +5,8 @@ config:
   enableTelemetry: false
   # --Defines if static files should be minified
   minifyStaticFiles: true
+  # -- Defines if in-app configuration changes should be preserved across container restarts
+  preserveConfig: false
   # --The default world to load when the server has started
   defaultWorld: ~
 


### PR DESCRIPTION
From the [docker image documentation](https://github.com/felddy/foundryvtt-docker?tab=readme-ov-file#optional-variables):

> Normally new `options.json` and `admin.txt` files are generated by the container at each startup. Setting this to true prevents the container from modifying these files when they exist. If they do not exist, they will be created as normal.

Adding this configuration value would enable persistent configuration of options that are currently only exposed in-app, like `Compress Web Socket Data`.

Removing an old/problematic `options.json / admin.txt` file is simple as setting `config.preserveConfig = false (default)`.

Happy to make my own charts, but I figured you'd appreciate the upstream push! `¯\_(ツ)_/¯`