### PR TITLE
chore(deps): update source repository for python-matter-server

### DIFF
--- a/home-assistant-matter-server/Chart.yaml
+++ b/home-assistant-matter-server/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 3.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.1" # renovate: datasource=github-releases depName=home-assistant-libs/python-matter-server
+appVersion: "8.1.1" # renovate: datasource=github-releases depName=matter-js/python-matter-server
 sources:
   - https://github.com/wittdennis/charts/tree/master/home-assistant-matter-server
 icon: https://raw.githubusercontent.com/wittdennis/charts/refs/heads/master/home-assistant-matter-server/assets/icon.png

--- a/home-assistant-matter-server/README.md
+++ b/home-assistant-matter-server/README.md
@@ -16,7 +16,7 @@ Helm chart for home assistant matter server
 | bluetoothCommissioning | object | `{"enabled":false}` | Flag to control if bluetooth commissioning should be enabled |
 | enableServiceLinks | bool | `true` | Indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links |
 | fullnameOverride | string | `""` |  |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/home-assistant-libs/python-matter-server","tag":""}` | This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/matter-js/python-matter-server","tag":""}` | This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ |
 | image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
@@ -45,4 +45,3 @@ Helm chart for home assistant matter server
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
 | volumes | list | `[]` | Additional volumes on the output Deployment definition. |
-

--- a/home-assistant-matter-server/values.yaml
+++ b/home-assistant-matter-server/values.yaml
@@ -1,6 +1,6 @@
 # -- This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: ghcr.io/home-assistant-libs/python-matter-server
+  repository: ghcr.io/matter-js/python-matter-server
   # -- This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
It seems like the ownership of the python-matter-server repository has been transferred and the old GHCR repository doesn't get updated anymore (which broke the chart with the `8.1.1` update.

Feel free to change/close the PR and just consider it an FYI if this doesn't work with your release automations/workflow.